### PR TITLE
I2C OLED has no reset pin to wire, pin 4 breaks I2C2 usage

### DIFF
--- a/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
+++ b/examples/ssd1306_128x64_i2c/ssd1306_128x64_i2c.ino
@@ -21,8 +21,7 @@ All text above, and the splash screen must be included in any redistribution
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 
-#define OLED_RESET 4
-Adafruit_SSD1306 display(OLED_RESET);
+Adafruit_SSD1306 display(-1);
 
 #define NUMFLAKES 10
 #define XPOS 0


### PR DESCRIPTION
This example is i2c specific and there is no device reset pin to connect

"...\Adafruit_SSD1306\examples\ssd1306_128x64_i2c\ssd1306_128x64_i2c.ino"

I suppose the same would apply to the sketch for the alternate 128x32 pixel layout but I don't have that to test:
"...\Adafruit_SSD1306\examples\ssd1306_128x32_i2c\ssd1306_128x32_i2c.ino"
